### PR TITLE
Implement pause menu and new enemy visuals

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -15,6 +15,12 @@
         <label style="color:#fff;font-size:1.1em;margin-top:1em;">Acelerar o tempo: <input type="checkbox" id="speedToggle" style="transform:scale(1.5);vertical-align:middle;" /></label>
         <div style="color:#aaa;margin-top:2em;font-size:1em;">Protótipo cooperativo multiplayer<br>por Webruxo</div>
     </div>
+    <div id="optionsMenu" style="position:fixed;left:0;top:0;width:100vw;height:100vh;z-index:90;background:linear-gradient(135deg,#23243a 60%,#2e3c5c 100%);display:none;flex-direction:column;align-items:center;justify-content:center;">
+        <h2 style="color:#fff;font-family:sans-serif;margin-bottom:1em;">Menu</h2>
+        <button id="restartBtn" style="font-size:1.2em;padding:0.5em 2em;margin:0.5em;border-radius:8px;border:none;background:#44c;color:#fff;box-shadow:0 2px 8px #000;cursor:pointer;">Reiniciar</button>
+        <button id="toggleSpeedBtn" style="font-size:1.2em;padding:0.5em 2em;margin:0.5em;border-radius:8px;border:none;background:#44c;color:#fff;box-shadow:0 2px 8px #000;cursor:pointer;">Alternar 2X</button>
+        <button id="closeMenuBtn" style="font-size:1em;padding:0.3em 1.5em;margin-top:1.5em;border-radius:8px;border:none;background:#666;color:#fff;cursor:pointer;">Fechar</button>
+    </div>
     <div id="info" style="display:none;">Conectando...</div>
     <canvas id="gameCanvas" style="display:none;"></canvas>
     <!-- Importa Three.js via CDN -->

--- a/public/main.js
+++ b/public/main.js
@@ -6,6 +6,10 @@ const canvas = document.getElementById('gameCanvas');
 const mainMenu = document.getElementById('mainMenu');
 const playBtn = document.getElementById('playBtn');
 const speedToggle = document.getElementById('speedToggle');
+const optionsMenu = document.getElementById('optionsMenu');
+const restartBtn = document.getElementById('restartBtn');
+const toggleSpeedBtn = document.getElementById('toggleSpeedBtn');
+const closeMenuBtn = document.getElementById('closeMenuBtn');
 const infoDiv = document.getElementById('info');
 const renderer = new THREE.WebGLRenderer({ canvas });
 renderer.setSize(window.innerWidth, window.innerHeight);
@@ -18,13 +22,26 @@ playBtn.onclick = () => {
     towerBar.style.display = '';
     statusBar.style.display = '';
 };
+
+// Opções de menu em jogo
+document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape') {
+        optionsMenu.style.display = optionsMenu.style.display === 'flex' ? 'none' : 'flex';
+    }
+});
+restartBtn.onclick = () => { location.reload(); };
+toggleSpeedBtn.onclick = () => {
+    speedToggle.checked = !speedToggle.checked;
+    socket.emit('speed_toggle', { fast: speedToggle.checked });
+};
+closeMenuBtn.onclick = () => { optionsMenu.style.display = 'none'; };
 // Esconde UI do jogo até clicar em Jogar
 canvas.style.display = 'none';
 infoDiv.style.display = 'none';
 let towerBar, statusBar;
 
 const scene = new THREE.Scene();
-scene.background = new THREE.Color(0x222233);
+scene.background = new THREE.Color(0x1e2438);
 
 // Câmera perspectiva
 const camera = new THREE.PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.1, 100);
@@ -36,10 +53,12 @@ scene.add(new THREE.AmbientLight(0xffffff, 0.7));
 
 // Chão simples
 const groundGeo = new THREE.PlaneGeometry(40, 40);
-const groundMat = new THREE.MeshPhongMaterial({ color: 0x444466 });
+const groundMat = new THREE.MeshPhongMaterial({ color: 0x353a50 });
 const ground = new THREE.Mesh(groundGeo, groundMat);
 ground.rotation.x = -Math.PI / 2;
 scene.add(ground);
+const gridHelper = new THREE.GridHelper(40, 40, 0x444477, 0x444477);
+scene.add(gridHelper);
 
 // Base central
 const baseGeo = new THREE.CylinderGeometry(1.5, 1.5, 1, 32);
@@ -281,7 +300,10 @@ function updateEnemies() {
             color += parseInt(enemy.id.substr(-2), 36) * 1000 % 0x10000;
         }
         const scale = 0.6 + (enemy.type === 'tank' ? 0.3 : 0) + ((enemy.id ? parseInt(enemy.id[0],36)%3 : 0)*0.07);
-        const geo = new THREE.SphereGeometry(scale, 12, 12);
+        let geo;
+        if (enemy.shape === 'cube') geo = new THREE.BoxGeometry(scale*1.2, scale*1.2, scale*1.2);
+        else if (enemy.shape === 'pyramid') geo = new THREE.ConeGeometry(scale, scale*1.6, 4);
+        else geo = new THREE.SphereGeometry(scale, 12, 12);
         const mat = new THREE.MeshPhongMaterial({ color });
         const mesh = new THREE.Mesh(geo, mat);
         mesh.position.set(enemy.x, scale, enemy.z);

--- a/server.js
+++ b/server.js
@@ -31,11 +31,17 @@ const ENEMY_TYPES = [
     { type: 'tank', hp: 60, speed: 0.012, damage: 20, reward: 20 },
 ];
 
-// Waypoints simples para os inimigos seguirem até a base central
-const WAYPOINTS = [
-    { x: -10, z: 10 },
-    { x: 0, z: 0 }, // base central
-];
+// Formas visuais possíveis para os inimigos
+const ENEMY_SHAPES = ['sphere', 'cube', 'pyramid'];
+
+// Gera caminho individual para cada inimigo
+function generatePath() {
+    return [
+        { x: (Math.random() - 0.5) * 10, z: (Math.random() - 0.5) * 10 },
+        { x: (Math.random() - 0.5) * 6, z: (Math.random() - 0.5) * 6 },
+        { x: 0, z: 0 }, // base
+    ];
+}
 
 // Função utilitária para gerar posição inicial dos inimigos
 function getEnemySpawnPosition(typeObj) {
@@ -45,11 +51,13 @@ function getEnemySpawnPosition(typeObj) {
     return {
         x: Math.cos(angle) * radius,
         z: Math.sin(angle) * radius,
+        path: generatePath(),
         waypointIndex: 0,
         hp: typeObj.hp,
         maxHp: typeObj.hp,
         speed: typeObj.speed,
         type: typeObj.type,
+        shape: ENEMY_SHAPES[Math.floor(Math.random() * ENEMY_SHAPES.length)],
         damage: typeObj.damage,
         reward: typeObj.reward,
         id: Math.random().toString(36).substr(2, 9),
@@ -97,13 +105,13 @@ function spawnWave(room) {
 // Lógica de movimentação dos inimigos
 function updateEnemies(room) {
     for (const enemy of room.enemies) {
-        const wp = WAYPOINTS[enemy.waypointIndex];
+        const wp = enemy.path[enemy.waypointIndex];
         if (!wp) continue;
         const dx = wp.x - enemy.x;
         const dz = wp.z - enemy.z;
         const dist = Math.sqrt(dx * dx + dz * dz);
         if (dist < 0.2) {
-            if (enemy.waypointIndex < WAYPOINTS.length - 1) {
+            if (enemy.waypointIndex < enemy.path.length - 1) {
                 enemy.waypointIndex++;
             } else {
                 // Chegou na base


### PR DESCRIPTION
## Summary
- allow enemy shapes and unique paths
- create an in-game menu with restart/speed toggle
- improve ground visuals with grid helper
- display different enemy geometries based on shape

## Testing
- `npm run build`
- `npm start` (server started successfully)

------
https://chatgpt.com/codex/tasks/task_e_6853791911b483248e37c24245170288