### PR TITLE
Add solo mode button and shorter wave interval

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -12,6 +12,7 @@
     <div id="mainMenu" style="position:fixed;left:0;top:0;width:100vw;height:100vh;z-index:100;background:linear-gradient(135deg,#23243a 60%,#2e3c5c 100%);display:flex;flex-direction:column;align-items:center;justify-content:center;">
         <h1 style="color:#fff;font-size:3em;font-family:sans-serif;letter-spacing:2px;text-shadow:2px 2px 8px #000;">Tower Guardians</h1>
         <button id="playBtn" style="font-size:1.5em;padding:0.6em 2em;margin:1em 0;border-radius:8px;border:none;background:#44c;color:#fff;box-shadow:0 2px 8px #000;cursor:pointer;">Jogar</button>
+        <button id="soloBtn" style="font-size:1.5em;padding:0.6em 2em;margin:0.5em 0;border-radius:8px;border:none;background:#44c;color:#fff;box-shadow:0 2px 8px #000;cursor:pointer;">Jogar Solo</button>
         <label style="color:#fff;font-size:1.1em;margin-top:1em;">Acelerar o tempo: <input type="checkbox" id="speedToggle" style="transform:scale(1.5);vertical-align:middle;" /></label>
         <div style="color:#aaa;margin-top:2em;font-size:1em;">Protótipo cooperativo multiplayer<br>por Webruxo</div>
     </div>

--- a/public/main.js
+++ b/public/main.js
@@ -5,6 +5,7 @@
 const canvas = document.getElementById('gameCanvas');
 const mainMenu = document.getElementById('mainMenu');
 const playBtn = document.getElementById('playBtn');
+const soloBtn = document.getElementById('soloBtn');
 const speedToggle = document.getElementById('speedToggle');
 const optionsMenu = document.getElementById('optionsMenu');
 const restartBtn = document.getElementById('restartBtn');
@@ -13,9 +14,18 @@ const closeMenuBtn = document.getElementById('closeMenuBtn');
 const infoDiv = document.getElementById('info');
 const renderer = new THREE.WebGLRenderer({ canvas });
 renderer.setSize(window.innerWidth, window.innerHeight);
+const WAVE_INTERVAL = 5000; // Deve coincidir com server.js
 
 // Menu inicial: só mostra o jogo após clicar em Jogar
 playBtn.onclick = () => {
+    mainMenu.style.display = 'none';
+    canvas.style.display = '';
+    infoDiv.style.display = '';
+    towerBar.style.display = '';
+    statusBar.style.display = '';
+};
+
+soloBtn.onclick = () => {
     mainMenu.style.display = 'none';
     canvas.style.display = '';
     infoDiv.style.display = '';

--- a/server.js
+++ b/server.js
@@ -19,7 +19,7 @@ const PORT = process.env.PORT || 3000;
 // Estrutura de dados para partidas (salas)
 const rooms = {};
 const MAX_PLAYERS = 3;
-let WAVE_INTERVAL = 20000; // 20 segundos entre waves
+let WAVE_INTERVAL = 5000; // 5 segundos entre waves
 let GAME_SPEED = 1; // 1x normal, 2x acelerado
 const ENEMIES_PER_WAVE_BASE = 5;
 const MAX_WAVES = 10;


### PR DESCRIPTION
## Summary
- add a **Jogar Solo** button in the menu
- handle the new button in `main.js`
- keep client/server wave interval in sync and shorten it to 5s

## Testing
- `npm run build`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_68538e4c33f083249c033439fb88dea1